### PR TITLE
Generate commitment list from map data

### DIFF
--- a/_pages/the-campaign.md
+++ b/_pages/the-campaign.md
@@ -19,6 +19,7 @@ At the start of every two year legislative session, the State House writes its o
 </script>
 
 #### **Did your Rep commit?**
+
 <div style="max-width: 800px; margin: 1rem auto;">
     <div style="position: relative; overflow: hidden; padding-top: 64%;">
     <iframe src="https://actonmass.github.io/campaign-map/"
@@ -26,21 +27,8 @@ At the start of every two year legislative session, the State House writes its o
     </div>
 </div>
 
-<ul>
-	<li>Rep. Mike Connolly (D-Cambridge), Amendments 1, 2, 3</li>
-	<li>Rep. Tami Gouveia (D-Acton), Amendments 1, 2</li>
-	<li>Rep. Natalie Higgins (D-Leominster), Amendments 1, 2</li>
-	<li>Rep. Russell Holmes (D-Mattapan), Amendments 1, 2, 3</li>
-	<li>Rep. Patrick Kearney (D-Scituate), Amendments 1, 2, 3</li>
-	<li>Rep. David LeBeouf (D-Worcester), Amendments 1, 2</li>
-	<li>Rep. Jack Lewis (D-Framingham), Amendments 1, 2</li>
-	<li>Rep. Steve Owens (D-Watertown), Amendments 1, 2, 3</li>
-	<li>Rep. Adam Scanlon (D-North Attleboro), Amendments 1, 2</li>
-	<li>Rep. Danillo Sena (D-Acton), Amendments 1, 2, 3</li>
-	<li>Rep. Paul Tucker (D-Salem), Amendment 1</li>
-	<li>Rep. Erika Uyterhoeven (D-Somerville), Amendments 1, 2, 3</li>
-	
-</ul>
+<script src="https://unpkg.com/papaparse@5.3.0/papaparse.min.js"></script>
+<script src="https://actonmass.github.io/campaign-map/commitment-list.js"></script>
 
 # The Massachusetts State House is broken.
 


### PR DESCRIPTION
Following up on my proposal in Slack, I thought it'd be helpful/fun for the list of reps to auto-update, using the tracker data that powers the map. Case in point: Vanna Howard is currently absent from the list, but her commitment is public and showing on the map.

The only difference is that it's missing the reps' city/town names, because those aren't listed in the tracker, and I couldn't find a canonical source for that. Any thoughts? Maybe they could be added to the "Party" column, e.g. "Democrat - Somerville"?

The script is at https://github.com/actonmass/campaign-map/blob/main/commitment-list.js. I'm expecting this PR will generate a preview on Netlify, but you can also see an example https://actonmass.github.io/campaign-map/embed/.