### PR TITLE
Add Toolkit in learn more menu

### DIFF
--- a/content/other/general_settings.yml
+++ b/content/other/general_settings.yml
@@ -21,6 +21,8 @@ learn_more_menu:
     title: Legislator Search
   - href: /blog
     title: Blog
+  - href: /Toolkit
+    title: Campaign Toolkit
 footer:
   - title: FAQs
     href: /faq


### PR DESCRIPTION
The following desired change is fixed (the Campaign Toolkit page is included in the menu under "Learn More", the last part may still need work depending if the functionality of the last part needs to change, but users can edit the info through netlify currently):
"Add "Campaign Toolkit" page
Should be included in menu under "Learn More"
Users should be able to add new and edit news entries through netlify content manager"