### PR TITLE
Reverse "next" and "previous" links on blog post page

### DIFF
--- a/content/pages/lte.md
+++ b/content/pages/lte.md
@@ -3,8 +3,8 @@ permalink: /LTE
 title: Write a Letter to the Editor
 layout: base
 ---
-<link rel='preload' href='https://static.everyaction.com/ea-actiontag/at.js' as='script' crossorigin='anonymous'>
- <link rel='preload' href='https://static.everyaction.com/ea-actiontag/at.min.css' as='style'>
+<link rel='preload' href='https://static.everyaction.com/ea-actiontag/at.js' as='script' crossorigin='anonymous' />
+ <link rel='preload' href='https://static.everyaction.com/ea-actiontag/at.min.css' as='style' />
  <script type='text/javascript' src='https://static.everyaction.com/ea-actiontag/at.js' crossorigin='anonymous'></script>
   <div class="ngp-form"
      data-form-url="https://secure.everyaction.com/v1/Forms/39gm3_6t2kySOrLDGBkPVg2"

--- a/src/layouts/pages/PostPage.tsx
+++ b/src/layouts/pages/PostPage.tsx
@@ -48,9 +48,9 @@ export default function PostPage({
             </div>
             <ul className="pager">
               <li>
-                {pageContext.next && (
-                  <Link to={pageContext.next.url} title={pageContext.next.title}>
-                    &larr; Next Post
+                {pageContext.previous && (
+                  <Link to={pageContext.previous.url} title={pageContext.previous.title}>
+                    &larr; Previous Post
                   </Link>
                 )}
               </li>
@@ -58,9 +58,9 @@ export default function PostPage({
                 <Link to="/blog">All posts</Link>
               </li>
               <li>
-                {pageContext.previous && (
-                  <Link to={pageContext.previous.url} title={pageContext.previous.title}>
-                    Previous Post &rarr;
+                {pageContext.next && (
+                  <Link to={pageContext.next.url} title={pageContext.next.title}>
+                    Next Post &rarr;
                   </Link>
                 )}
               </li>


### PR DESCRIPTION
Travis pointed out that the navigation links for next and previous post at the bottom of our blog post page were reversed from what seems to be the typical practice on blog post pages:
![image](https://github.com/actonmass/actonmass.org/assets/6565058/e4c5e494-9a5b-4b19-a300-1b106796c788)

This PR puts "Previous Post" on the left and "Next Post" on the right.

I also fixed a build error that doesn't stop the build locally or during prod deploy, but causes the CI build check to report a failure, so hopefully that check will succeed for this PR 🤞 

Update: Well it got past that error and failed on a different (later) error, so I'll call this a partial win.